### PR TITLE
load model onto cpu if cuda isn't available

### DIFF
--- a/segment_anything/build_sam.py
+++ b/segment_anything/build_sam.py
@@ -103,7 +103,8 @@ def _build_sam(
     # sam.eval()
     if checkpoint is not None:
         with open(checkpoint, "rb") as f:
-            state_dict = torch.load(f)
+            device = "cuda" if torch.cuda.is_available() else "cpu"
+            state_dict = torch.load(f, map_location=device)
         info = sam.load_state_dict(state_dict, strict=False)
         print(info)
     for n, p in sam.named_parameters():


### PR DESCRIPTION
## Load the model onto cpu if cuda device isn't available

As it stands, the user has to go down to the code to change where the weights/ckpt is loaded into. This fix loads the ckpt into a device dynamically, based on which device is present.