### PR TITLE
Add timm dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     install_requires=[],
     packages=find_packages(exclude="notebooks"),
     extras_require={
-        "all": ["matplotlib", "pycocotools", "opencv-python", "onnx", "onnxruntime"],
+        "all": ["matplotlib", "pycocotools", "opencv-python", "onnx", "onnxruntime", "timm"],
         "dev": ["flake8", "isort", "black", "mypy"],
     },
 )


### PR DESCRIPTION
I am adding the `segment-anything-hq` package to conda-forge. https://github.com/conda-forge/staged-recipes/pull/23663
Just noticed that the `segment-anything-hq` PyPI package is mssing the `timm` dependency, which causes issues for the conda-forge build. `timm` should be added. 

> import: 'segment_anything_hq'
Traceback (most recent call last):
  File "/home/conda/staged-recipes/build_artifacts/segment-anything-hq_1691897321239/test_tmp/run_test.py", line 2, in <module>
    import segment_anything_hq
  File "/home/conda/staged-recipes/build_artifacts/segment-anything-hq_1691897321239/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeh/lib/python3.11/site-packages/segment_anything_hq/__init__.py", line 7, in <module>
    from .build_sam import (
  File "/home/conda/staged-recipes/build_artifacts/segment-anything-hq_1691897321239/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeh/lib/python3.11/site-packages/segment_anything_hq/build_sam.py", line 11, in <module>
    from .modeling import ImageEncoderViT, MaskDecoderHQ, PromptEncoder, Sam, TwoWayTransformer, TinyViT
  File "/home/conda/staged-recipes/build_artifacts/segment-anything-hq_1691897321239/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeh/lib/python3.11/site-packages/segment_anything_hq/modeling/__init__.py", line 13, in <module>
    from .tiny_vit_sam import TinyViT
  File "/home/conda/staged-recipes/build_artifacts/segment-anything-hq_1691897321239/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeh/lib/python3.11/site-packages/segment_anything_hq/modeling/tiny_vit_sam.py", line 15, in <module>
    from timm.models.layers import DropPath as TimmDropPath,\
ModuleNotFoundError: No module named 'timm'
